### PR TITLE
feat: support parallel chats and thread state persistence

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -48,6 +48,8 @@ export class LlmHubPlugin extends Plugin {
   private encryptionManager!: EncryptionManager;
   private lastActiveMarkdownView: MarkdownView | null = null;
   private workflowMgr!: WorkflowManager;
+  /** In-memory only – cleared on Obsidian restart */
+  lastActiveChatId: string | null = null;
 
   // Delegate workspaceState to the manager
   get workspaceState(): WorkspaceState {

--- a/src/ui/components/Chat.tsx
+++ b/src/ui/components/Chat.tsx
@@ -137,6 +137,8 @@ function getPendingInfos<T>(items: T[]): T[] | undefined {
 	return items.length > 0 ? items : undefined;
 }
 
+const MAX_BACKGROUND_STREAMS = 3;
+
 interface ChatProps {
 	plugin: LlmHubPlugin;
 }
@@ -191,6 +193,14 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 		mcpServers: McpServerConfig[];
 	} | null>(null);
 	const mcpExecutorRef = useRef<McpToolExecutor | null>(null);
+	// Session ID to track which chat session owns the UI; incremented on startNewChat
+	// so background streams can detect they've been detached from the UI.
+	const activeSessionIdRef = useRef(0);
+	// AbortControllers for background (detached) streams, capped at MAX_BACKGROUND_STREAMS.
+	const backgroundAbortControllersRef = useRef<AbortController[]>([]);
+	// Chat IDs that have been deleted — background streams check this to avoid
+	// resurrecting a deleted chat when they complete.
+	const deletedChatIdsRef = useRef<Set<string>>(new Set());
 	const [vaultFiles, setVaultFiles] = useState<string[]>([]);
 	const [hasSelection, setHasSelection] = useState(false);
 	const [cliConfig, setCliConfig] = useState(plugin.settings.cliConfig || DEFAULT_CLI_CONFIG);
@@ -400,47 +410,62 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 		}
 	}, [plugin]);
 
-	// Save current chat to Markdown file
-	const saveCurrentChat = useCallback(async (msgs: Message[], session?: CliSessionInfo | null, overrideChatId?: string) => {
+	// Write a chat to disk and update the history list.
+	// When `foreground` is true, also sets currentChatId (normal save).
+	// When false, uses setChatHistories functional updater to avoid stale-closure
+	// races (background save – the foreground chat is not disturbed).
+	const saveChatToDisk = useCallback(async (
+		msgs: Message[],
+		chatId: string,
+		opts: { session?: CliSessionInfo | null; foreground?: boolean } = {},
+	) => {
 		if (msgs.length === 0) return;
 		if (!plugin.settings.saveChatHistory) return;
+		// Skip if this chat was deleted while the stream was running
+		if (deletedChatIdsRef.current.has(chatId)) return;
 
-		const chatId = overrideChatId || currentChatId || generateChatId();
+		const { session, foreground = false } = opts;
 		const title = msgs[0].content.slice(0, 50) + (msgs[0].content.length > 50 ? "..." : "");
 		const folder = getChatHistoryFolder();
 
-		// Ensure folder exists
 		try {
-			const folderExists = await plugin.app.vault.adapter.exists(folder);
-			if (!folderExists) {
+			if (!(await plugin.app.vault.adapter.exists(folder))) {
 				await plugin.app.vault.adapter.mkdir(folder);
 			}
 		} catch {
 			// Folder might already exist
 		}
 
-		const existingHistory = chatHistories.find(h => h.id === chatId);
-		const createdAt = existingHistory?.createdAt || Date.now();
-		// Use provided session when explicitly set/cleared, otherwise fall back to existing history's session
-		const effectiveSession = session === undefined
-			? existingHistory?.cliSession
-			: session ?? undefined;
+		// Use functional updater to read the latest chatHistories without
+		// depending on the outer closure (avoids stale-closure races).
+		// We capture the existing entry's createdAt and cliSession here
+		// and write the file inside the updater so everything stays consistent.
+		setChatHistories(prev => {
+			const existing = prev.find(h => h.id === chatId);
+			const createdAt = existing?.createdAt || Date.now();
+			// session explicitly passed → use it; undefined → fall back to existing
+			const effectiveSession = session === undefined
+				? existing?.cliSession
+				: session ?? undefined;
 
-		const markdown = await messagesToMarkdown(msgs, title, createdAt, plugin.settings.encryption, effectiveSession);
-		const basePath = getChatFilePath(chatId);
-		const encrypted = isEncryptedFile(markdown);
-		const filePath = encrypted ? basePath + ".encrypted" : basePath;
-		const oldPath = encrypted ? basePath : basePath + ".encrypted";
+			// Fire-and-forget the async disk write; state update is synchronous
+			void (async () => {
+				try {
+					const markdown = await messagesToMarkdown(msgs, title, createdAt, plugin.settings.encryption, effectiveSession);
+					const basePath = getChatFilePath(chatId);
+					const encrypted = isEncryptedFile(markdown);
+					const filePath = encrypted ? basePath + ".encrypted" : basePath;
+					const oldPath = encrypted ? basePath : basePath + ".encrypted";
 
-		try {
-			// Delete old file if encryption status changed (extension mismatch)
-			if (await plugin.app.vault.adapter.exists(oldPath)) {
-				await plugin.app.vault.adapter.remove(oldPath);
-			}
+					if (await plugin.app.vault.adapter.exists(oldPath)) {
+						await plugin.app.vault.adapter.remove(oldPath);
+					}
+					await plugin.app.vault.adapter.write(filePath, markdown);
+				} catch (e) {
+					console.warn("Failed to write chat file:", chatId, e);
+				}
+			})();
 
-			await plugin.app.vault.adapter.write(filePath, markdown);
-
-			// Update local state
 			const newHistory: ChatHistory = {
 				id: chatId,
 				title,
@@ -450,30 +475,138 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 				cliSession: effectiveSession,
 			};
 
-			const existingIndex = chatHistories.findIndex(h => h.id === chatId);
-			let newHistories: ChatHistory[];
-
-			if (existingIndex >= 0) {
-				newHistories = [...chatHistories];
-				newHistories[existingIndex] = newHistory;
+			const idx = prev.findIndex(h => h.id === chatId);
+			let updated: ChatHistory[];
+			if (idx >= 0) {
+				updated = [...prev];
+				updated[idx] = newHistory;
 			} else {
-				newHistories = [newHistory, ...chatHistories];
+				updated = [newHistory, ...prev];
 			}
+			return updated.slice(0, 50);
+		});
 
-			// Keep only last 50 chats
-			newHistories = newHistories.slice(0, 50);
-
-			setChatHistories(newHistories);
+		if (foreground) {
 			setCurrentChatId(chatId);
-		} catch {
-			// Failed to save chat
 		}
-	}, [currentChatId, chatHistories, plugin]);
+	}, [plugin]);
 
-	// Load chat histories on mount
+	// Save current (foreground) chat to Markdown file
+	const saveCurrentChat = useCallback(async (msgs: Message[], session?: CliSessionInfo | null, overrideChatId?: string) => {
+		const chatId = overrideChatId || currentChatId || generateChatId();
+		await saveChatToDisk(msgs, chatId, { session, foreground: true });
+	}, [currentChatId, saveChatToDisk]);
+
+	// Create a stream session that tracks whether this stream still owns the UI.
+	// Each provider function calls this once at the top; the returned helpers
+	// centralise the isActive/save/finally logic that was previously duplicated.
+	const createStreamSession = useCallback(() => {
+		const mySessionId = activeSessionIdRef.current;
+		const myChatId = currentChatId || generateChatId();
+		const isActive = () => mySessionId === activeSessionIdRef.current;
+
+		const saveResult = async (msgs: Message[], session?: CliSessionInfo | null) => {
+			if (isActive()) {
+				setMessages(msgs);
+				await saveChatToDisk(msgs, myChatId, { session, foreground: true });
+			} else {
+				await saveChatToDisk(msgs, myChatId, { session });
+			}
+		};
+
+		const addErrorMessage = (errorMsg: Message) => {
+			if (isActive()) {
+				setMessages(prev => [...prev, errorMsg]);
+			}
+		};
+
+		// Called in `finally` — cleans up UI state if still foreground.
+		// Pass the stream's AbortController so it can be removed from
+		// the background tracking list when the stream was backgrounded.
+		const cleanup = (myAbortController?: AbortController | null) => {
+			if (isActive()) {
+				setIsLoading(false);
+				setStreamingContent("");
+				setStreamingThinking("");
+				abortControllerRef.current = null;
+			} else if (myAbortController) {
+				const bgList = backgroundAbortControllersRef.current;
+				backgroundAbortControllersRef.current = bgList.filter(ac => ac !== myAbortController);
+			}
+		};
+
+		return { mySessionId, myChatId, isActive, saveResult, addErrorMessage, cleanup };
+	}, [currentChatId, saveChatToDisk]);
+
+	// Detach the currently running stream (if any) so it continues in the
+	// background.  Moves its AbortController to the background list and
+	// aborts the oldest background stream if we exceed the cap.
+	const detachActiveStream = useCallback(() => {
+		activeSessionIdRef.current += 1;
+
+		// Move the foreground AbortController to the background list
+		if (abortControllerRef.current) {
+			backgroundAbortControllersRef.current.push(abortControllerRef.current);
+			abortControllerRef.current = null;
+			// Abort oldest if over the cap
+			while (backgroundAbortControllersRef.current.length > MAX_BACKGROUND_STREAMS) {
+				const oldest = backgroundAbortControllersRef.current.shift();
+				oldest?.abort();
+			}
+		}
+
+		// Detach MCP executor – background stream cleans up its own copy
+		mcpExecutorRef.current = null;
+		setIsLoading(false);
+		setStreamingContent("");
+		setStreamingThinking("");
+	}, []);
+
+	// Load chat histories on mount, and restore last active chat if available
 	useEffect(() => {
-		void loadChatHistories();
+		// Capture session ID at mount time so we can detect if the user
+		// navigated elsewhere before the async restore completes.
+		const mountSessionId = activeSessionIdRef.current;
+		void loadChatHistories().then(() => {
+			// Skip restore if the user already started a new chat or loaded one
+			if (activeSessionIdRef.current !== mountSessionId) return;
+
+			const lastId = plugin.lastActiveChatId;
+			if (!lastId) return;
+
+			void (async () => {
+				try {
+					const basePath = getChatFilePath(lastId);
+					let filePath = basePath;
+					let exists = await plugin.app.vault.adapter.exists(filePath);
+					if (!exists) {
+						filePath = basePath + ".encrypted";
+						exists = await plugin.app.vault.adapter.exists(filePath);
+					}
+					if (!exists) return;
+					// Re-check after async gap
+					if (activeSessionIdRef.current !== mountSessionId) return;
+
+					const content = await plugin.app.vault.adapter.read(filePath);
+					if (isEncryptedFile(content)) return;
+
+					const parsed = parseMarkdownToMessages(content);
+					if (parsed?.messages && parsed.messages.length > 0) {
+						// Final check before touching state
+						if (activeSessionIdRef.current !== mountSessionId) return;
+						setMessages(parsed.messages);
+						setCurrentChatId(lastId);
+						setCliSession(parsed.cliSession || null);
+					}
+				} catch (e) { console.warn("Failed to restore last active chat:", e); }
+			})();
+		});
 	}, [loadChatHistories]);
+
+	// Sync currentChatId → plugin.lastActiveChatId (in-memory, cleared on restart)
+	useEffect(() => {
+		plugin.lastActiveChatId = currentChatId;
+	}, [currentChatId, plugin]);
 
 	// Discover skills (on mount + when skills-changed is emitted)
 	const refreshSkills = useCallback(() => {
@@ -928,31 +1061,34 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 		return command.promptTemplate;
 	};
 
-	// Start new chat
+	// Start new chat (works even while a stream is running – the old stream
+	// continues in the background and saves its result to history when done).
 	const startNewChat = () => {
 		if (isLoading) {
-			new Notice(t("chat.generationInProgress"));
-			return;
+			detachActiveStream();
+		} else {
+			// Bump session ID even without an active stream so that
+			// pending async operations (e.g. mount-time restore) are cancelled.
+			activeSessionIdRef.current += 1;
+			if (mcpExecutorRef.current) {
+				void mcpExecutorRef.current.cleanup();
+				mcpExecutorRef.current = null;
+			}
 		}
+
 		setMessages([]);
 		setCurrentChatId(null);
 		setActiveSkillPaths(DEFAULT_BUILTIN_SKILL_IDS.map(builtinFolderPath));
-		setCliSession(null);  // Clear CLI session
-		setStreamingContent("");
-		setStreamingThinking("");
+		setCliSession(null);
 		setShowHistory(false);
-		// Cleanup MCP executor session
-		if (mcpExecutorRef.current) {
-			void mcpExecutorRef.current.cleanup();
-			mcpExecutorRef.current = null;
-		}
 	};
 
 	// Decrypt and load encrypted chat
 	const decryptAndLoadChat = async (chatId: string, password: string) => {
 		if (isLoading) {
-			new Notice(t("chat.generationInProgress"));
-			return;
+			detachActiveStream();
+		} else {
+			activeSessionIdRef.current += 1;
 		}
 		try {
 			// Try .md.encrypted first, then fall back to .md
@@ -1001,8 +1137,9 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 	// Load a chat from history
 	const loadChat = (history: ChatHistory) => {
 		if (isLoading) {
-			new Notice(t("chat.generationInProgress"));
-			return;
+			detachActiveStream();
+		} else {
+			activeSessionIdRef.current += 1;
 		}
 		if (history.isEncrypted) {
 			// If password is cached, try to decrypt automatically
@@ -1027,10 +1164,9 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 	// Delete a chat from history
 	const deleteChat = async (chatId: string, e: React.MouseEvent) => {
 		e.stopPropagation();
-		if (isLoading) {
-			new Notice(t("chat.generationInProgress"));
-			return;
-		}
+
+		// Prevent background streams from resurrecting this chat
+		deletedChatIdsRef.current.add(chatId);
 
 		// Delete the Markdown file (try both .md and .md.encrypted)
 		const basePath = getChatFilePath(chatId);
@@ -1055,6 +1191,8 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 
 	// Send message via CLI provider
 	const sendMessageViaCli = async (content: string, attachments?: Attachment[], skillPath?: string) => {
+		const { isActive, saveResult, addErrorMessage, cleanup: cleanupStream } = createStreamSession();
+
 		const isClaudeCli = currentModel === "claude-cli";
 		const isCodexCli = currentModel === "codex-cli";
 		const provider = isClaudeCli
@@ -1196,7 +1334,7 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 				switch (chunk.type) {
 					case "text":
 						fullContent += chunk.content || "";
-						setStreamingContent(fullContent);
+						if (isActive()) setStreamingContent(fullContent);
 						break;
 
 					case "session_id":
@@ -1223,7 +1361,7 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 				? { provider: currentProvider, sessionId: receivedSessionId }
 				: (cliSession?.provider === currentProvider ? cliSession : null);
 
-			if (receivedSessionId || cliSession?.provider !== currentProvider) {
+			if (isActive() && (receivedSessionId || cliSession?.provider !== currentProvider)) {
 				setCliSession(newSession);
 			}
 
@@ -1266,9 +1404,7 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 			};
 
 			const newMessages = [...messages, userMessage, assistantMessage];
-			setMessages(newMessages);
-			// Save chat history (with session info)
-			await saveCurrentChat(newMessages, newSession || undefined);
+			await saveResult(newMessages, newSession || undefined);
 
 			tracing.traceEnd(cliTraceId, { output: processedContent });
 			tracing.score(cliTraceId, {
@@ -1278,24 +1414,22 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 			});
 		} catch (error) {
 			const errorMessageText = error instanceof Error ? error.message : t("chat.unknownError");
-			const errorMessage: Message = {
+			addErrorMessage({
 				role: "assistant",
 				content: t("chat.errorOccurred", { message: errorMessageText }),
 				timestamp: Date.now(),
-			};
-			setMessages((prev) => [...prev, errorMessage]);
+			});
 			tracing.traceEnd(cliTraceId, { output: errorMessageText, metadata: { error: true } });
 			tracing.score(cliTraceId, { name: "status", value: 0, comment: errorMessageText });
 		} finally {
-			setIsLoading(false);
-			setStreamingContent("");
-			setStreamingThinking("");
-			abortControllerRef.current = null;
+			cleanupStream(abortController);
 		}
 	};
 
 	// Send message via Local LLM provider
 	const sendMessageViaLocalLlm = async (content: string, attachments?: Attachment[], skillPath?: string) => {
+		const { isActive, saveResult, addErrorMessage, cleanup: cleanupStream } = createStreamSession();
+
 		const llmConfig = plugin.settings.localLlmConfig || DEFAULT_LOCAL_LLM_CONFIG;
 
 		// Activate skill if invoked via slash command
@@ -1424,12 +1558,12 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 				switch (chunk.type) {
 					case "text":
 						fullContent += chunk.content || "";
-						setStreamingContent(fullContent);
+						if (isActive()) setStreamingContent(fullContent);
 						break;
 
 					case "thinking":
 						fullThinking += chunk.content || "";
-						setStreamingThinking(fullThinking);
+						if (isActive()) setStreamingThinking(fullThinking);
 						break;
 
 					case "error":
@@ -1484,9 +1618,8 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 			};
 
 			const newMessages = [...messages, userMessage, assistantMessage];
-			setMessages(newMessages);
-			setCliSession(null);
-			await saveCurrentChat(newMessages, null);
+			if (isActive()) setCliSession(null);
+			await saveResult(newMessages, null);
 
 			tracing.traceEnd(llmTraceId, { output: processedContent });
 			tracing.score(llmTraceId, {
@@ -1496,24 +1629,22 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 			});
 		} catch (error) {
 			const errorMessageText = error instanceof Error ? error.message : t("chat.unknownError");
-			const errorMessage: Message = {
+			addErrorMessage({
 				role: "assistant",
 				content: t("chat.errorOccurred", { message: errorMessageText }),
 				timestamp: Date.now(),
-			};
-			setMessages((prev) => [...prev, errorMessage]);
+			});
 			tracing.traceEnd(llmTraceId, { output: errorMessageText, metadata: { error: true } });
 			tracing.score(llmTraceId, { name: "status", value: 0, comment: errorMessageText });
 		} finally {
-			setIsLoading(false);
-			setStreamingContent("");
-			setStreamingThinking("");
-			abortControllerRef.current = null;
+			cleanupStream(abortController);
 		}
 	};
 
 	// Send message via API provider (OpenAI-compatible)
 	const sendMessageViaApiProvider = async (content: string, attachments?: Attachment[], skillPath?: string) => {
+		const { isActive, saveResult, addErrorMessage, cleanup: cleanupStream } = createStreamSession();
+
 		const providerConfig = getActiveApiProvider();
 		const resolvedModelName = getApiProviderModelName(currentModel) || providerConfig?.enabledModels[0] || "";
 		if (!providerConfig) {
@@ -1933,12 +2064,12 @@ Always be helpful and provide clear, concise responses. When working with notes,
 				switch (chunk.type) {
 					case "text":
 						fullContent += chunk.content || "";
-						setStreamingContent(fullContent);
+						if (isActive()) setStreamingContent(fullContent);
 						break;
 
 					case "thinking":
 						thinkingContent += chunk.content || "";
-						setStreamingThinking(thinkingContent);
+						if (isActive()) setStreamingThinking(thinkingContent);
 						break;
 
 					case "tool_call":
@@ -1968,7 +2099,7 @@ Always be helpful and provide clear, concise responses. When working with notes,
 
 			// Cleanup MCP
 			if (mcpToolExecutor) {
-				try { await mcpToolExecutor.cleanup(); } catch { /* ignore */ }
+				try { await mcpToolExecutor.cleanup(); } catch (e) { console.warn("MCP cleanup failed:", e); }
 			}
 
 			// Get processed edit/delete/rename info from tool executor
@@ -2001,10 +2132,7 @@ Always be helpful and provide clear, concise responses. When working with notes,
 				elapsedMs,
 			};
 			const newMessages = [...messages, userMessage, assistantMessage];
-			setMessages(newMessages);
-
-			// Save chat history
-			await saveCurrentChat(newMessages);
+			await saveResult(newMessages);
 
 			tracing.traceEnd(apiTraceId, { output: fullContent });
 			tracing.score(apiTraceId, {
@@ -2014,19 +2142,15 @@ Always be helpful and provide clear, concise responses. When working with notes,
 			});
 		} catch (error) {
 			const errorMessageText = error instanceof Error ? error.message : t("chat.unknownError");
-			const errorMessage: Message = {
+			addErrorMessage({
 				role: "assistant",
 				content: t("chat.errorOccurred", { message: errorMessageText }),
 				timestamp: Date.now(),
-			};
-			setMessages((prev) => [...prev, errorMessage]);
+			});
 			tracing.traceEnd(apiTraceId, { output: errorMessageText, metadata: { error: true } });
 			tracing.score(apiTraceId, { name: "status", value: 0, comment: errorMessageText });
 		} finally {
-			setIsLoading(false);
-			setStreamingContent("");
-			setStreamingThinking("");
-			abortControllerRef.current = null;
+			cleanupStream(abortController);
 		}
 	};
 
@@ -2064,6 +2188,8 @@ Always be helpful and provide clear, concise responses. When working with notes,
 
 	// Send message via Gemini provider (uses @google/genai SDK)
 	const sendMessageViaGemini = async (content: string, attachments?: Attachment[], skillPath?: string, providerConfig?: ApiProviderConfig) => {
+		const { isActive, saveResult, addErrorMessage, cleanup: cleanupStream } = createStreamSession();
+
 		const apiKey = providerConfig?.apiKey || getGeminiApiKey(plugin.settings);
 		if (!apiKey) {
 			new Notice(t("chat.clientNotInitialized"));
@@ -2128,6 +2254,12 @@ Always be helpful and provide clear, concise responses. When working with notes,
 			input: resolvedContent,
 		});
 
+		// Track MCP executor for background-stream cleanup (hoisted so the
+		// outer finally block can reach it even though it's created inside
+		// runStreamOnce).  Wrapped in an object to avoid TypeScript narrowing
+		// issues with `let` variables reassigned inside nested closures.
+		const mcpCleanupRef = { executor: null as McpToolExecutor | null };
+
 		try {
 			const runStreamOnce = async () => {
 				const { settings } = plugin;
@@ -2173,8 +2305,9 @@ Always be helpful and provide clear, concise responses. When working with notes,
 					? createMcpToolExecutor(mcpTools, traceId)
 					: undefined;
 
-				// Store for session reuse
+				// Store for session reuse and track for background-stream cleanup
 				mcpExecutorRef.current = mcpToolExecutor ?? null;
+				mcpCleanupRef.executor = mcpToolExecutor ?? null;
 
 				// Merge Obsidian tools and MCP tools
 				const allTools = [...obsidianTools, ...mcpTools];
@@ -2665,19 +2798,17 @@ Always be helpful and provide clear, concise responses. When working with notes,
 				switch (chunk.type) {
 					case "text":
 						fullContent += chunk.content || "";
-						setStreamingContent(fullContent);
+						if (isActive()) setStreamingContent(fullContent);
 						break;
 
 					case "thinking":
 						thinkingContent += chunk.content || "";
-						// thinkingは別stateで管理（折りたたみ表示用）
-						setStreamingThinking(thinkingContent);
+						if (isActive()) setStreamingThinking(thinkingContent);
 						break;
 
 					case "tool_call":
 						if (chunk.toolCall) {
 							toolCalls.push(chunk.toolCall);
-							// ツール名を記録（重複なし）
 							if (!toolsUsed.includes(chunk.toolCall.name)) {
 								toolsUsed.push(chunk.toolCall.name);
 							}
@@ -2693,7 +2824,6 @@ Always be helpful and provide clear, concise responses. When working with notes,
 					case "rag_used":
 						ragUsed = true;
 						if (chunk.ragSources) {
-							// Merge grounding sources after local RAG sources (avoid overwriting)
 							for (const s of chunk.ragSources) {
 								if (!ragSources.includes(s)) {
 									ragSources.push(s);
@@ -2745,7 +2875,7 @@ Always be helpful and provide clear, concise responses. When working with notes,
 				currentSlashCommandRef.current = null;
 
 				// Restore chat settings that were overridden by the slash command
-				if (preSlashSettingsRef.current) {
+				if (isActive() && preSlashSettingsRef.current) {
 					const saved = preSlashSettingsRef.current;
 					preSlashSettingsRef.current = null;
 					setCurrentModel(saved.model);
@@ -2784,10 +2914,7 @@ Always be helpful and provide clear, concise responses. When working with notes,
 				};
 
 				const newMessages = [...messages, userMessage, assistantMessage];
-				setMessages(newMessages);
-
-				// Save chat history
-				await saveCurrentChat(newMessages);
+				await saveResult(newMessages);
 
 				tracing.traceEnd(traceId, {
 					output: fullContent,
@@ -2807,10 +2934,9 @@ Always be helpful and provide clear, concise responses. When working with notes,
 				});
 
 				// Check if user requested changes with feedback - use state to trigger send after re-render
-				if (pendingAdditionalRequestRef.current) {
+				if (isActive() && pendingAdditionalRequestRef.current) {
 					const requestInfo = pendingAdditionalRequestRef.current;
-					pendingAdditionalRequestRef.current = null; // Clear to prevent re-sending
-					// Set state to trigger useEffect which will send the message after messages state is updated
+					pendingAdditionalRequestRef.current = null;
 					setPendingEditFeedback(requestInfo);
 				}
 			};
@@ -2824,8 +2950,10 @@ Always be helpful and provide clear, concise responses. When working with notes,
 					break;
 				} catch (error) {
 					if (abortController.signal.aborted) {
-						setStreamingContent("");
-						setStreamingThinking("");
+						if (isActive()) {
+							setStreamingContent("");
+							setStreamingThinking("");
+						}
 						tracing.traceEnd(traceId, { metadata: { status: "aborted" } });
 						tracing.score(traceId, { name: "status", value: 0.5, comment: "aborted during retry" });
 						return;
@@ -2833,8 +2961,10 @@ Always be helpful and provide clear, concise responses. When working with notes,
 					if (isRateLimitError(error) && retryCount < retryDelays.length) {
 						const delayMs = retryDelays[retryCount];
 						retryCount += 1;
-						setStreamingContent("");
-						setStreamingThinking("");
+						if (isActive()) {
+							setStreamingContent("");
+							setStreamingThinking("");
+						}
 						new Notice(
 							t("chat.rateLimitRetrying", {
 								seconds: String(Math.ceil(delayMs / 1000)),
@@ -2850,12 +2980,11 @@ Always be helpful and provide clear, concise responses. When working with notes,
 			}
 		} catch (error) {
 			const errorMessageText = buildErrorMessage(error);
-			const errorMessage: Message = {
+			addErrorMessage({
 				role: "assistant",
 				content: errorMessageText,
 				timestamp: Date.now(),
-			};
-			setMessages((prev) => [...prev, errorMessage]);
+			});
 			tracing.traceEnd(traceId, {
 				output: errorMessageText,
 				metadata: { error: true },
@@ -2866,10 +2995,12 @@ Always be helpful and provide clear, concise responses. When working with notes,
 				comment: errorMessageText,
 			});
 		} finally {
-			setIsLoading(false);
-			setStreamingContent("");
-			setStreamingThinking("");
-			abortControllerRef.current = null;
+			cleanupStream(abortController);
+			// Stream was backgrounded – clean up our own MCP executor since
+			// the ref was detached when the stream was backgrounded.
+			if (!isActive() && mcpCleanupRef.executor) {
+				try { await mcpCleanupRef.executor.cleanup(); } catch (e) { console.warn("Background MCP cleanup failed:", e); }
+			}
 		}
 	};
 


### PR DESCRIPTION
Allow starting a new chat while a response is still streaming. The old stream continues in the background and saves its result to history.

- createStreamSession() centralises isActive/save/error/cleanup logic across all 4 provider functions (CLI, LocalLLM, API, Gemini)
- detachActiveStream() handles stream backgrounding with AbortController tracking (cap of 3 concurrent background streams)
- saveChatToDisk() unifies foreground/background chat persistence
- Persist lastActiveChatId in-memory so reopening the Chat view within the same Obsidian session restores the previous thread
- Prevent deleted chat resurrection via deletedChatIdsRef
- Guard mount-time restore against race conditions via activeSessionIdRef