### PR TITLE
Privacy ACL + settings bugfix

### DIFF
--- a/src/core/localRagStore.ts
+++ b/src/core/localRagStore.ts
@@ -838,13 +838,14 @@ export async function searchLocalRag(
   fallbackApiKey: string,
   proxyUrl?: string,
   proxyBypass?: string,
+  fileFilter?: (filePath: string) => boolean,
 ): Promise<LocalRagResult> {
   const store = getLocalRagStore();
   const apiKey = ragSetting.embeddingApiKey || fallbackApiKey;
   if (!store || !apiKey) {
     return { context: "", sources: [], mediaReferences: [] };
   }
-  const results = await store.search(
+  let results = await store.search(
     settingName, query, apiKey,
     ragSetting.embeddingModel || (ragSetting.embeddingBaseUrl ? "" : DEFAULT_GEMINI_EMBEDDING_MODEL), ragSetting.topK,
     ragSetting.embeddingBaseUrl || undefined,
@@ -852,6 +853,9 @@ export async function searchLocalRag(
     ragSetting.searchFileExtensions,
     proxyUrl, proxyBypass,
   );
+  if (fileFilter) {
+    results = results.filter(r => fileFilter(r.filePath));
+  }
   if (results.length === 0) {
     return { context: "", sources: [], mediaReferences: [] };
   }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -138,6 +138,17 @@ export const en = {
   "settings.systemPrompt.desc": "Additional instructions for the AI assistant",
   "settings.systemPrompt.placeholder": "Respond in the same language as the question.",
 
+  // Settings - Privacy
+  "settings.privacy": "Privacy",
+  "settings.privacyEnabled": "Enable privacy filtering for cloud providers",
+  "settings.privacyEnabled.desc": "When enabled, notes tagged as private and notes in private folders are blocked from cloud/API models. Local LLMs retain full access.",
+  "settings.privateTag": "Private tag",
+  "settings.privateTag.desc": "Frontmatter tag that marks a note as private (e.g. add tags: [private] to a note)",
+  "settings.privateTag.placeholder": "private",
+  "settings.privateFolders": "Private folders",
+  "settings.privateFolders.desc": "Comma-separated folder paths fully blocked for cloud providers",
+  "settings.privateFolders.placeholder": "e.g. Personal, Journals, Finance",
+
   // Settings - Tool limits
   "settings.maxToolCalls": "Max tool calls per request",
   "settings.maxToolCalls.desc": "Upper limit for function calls during a single response",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -35,7 +35,7 @@ import {
 } from "src/core/editHistory";
 import { EditHistoryModal } from "src/ui/components/EditHistoryModal";
 import { formatError } from "src/utils/error";
-import { DEFAULT_CLI_CONFIG, DEFAULT_DISCORD_SETTINGS, DEFAULT_EDIT_HISTORY_SETTINGS, DEFAULT_GEMINI_EMBEDDING_MODEL, DEFAULT_LANGFUSE_SETTINGS, DEFAULT_WORKSPACE_FOLDER, hasVerifiedCli } from "src/types";
+import { DEFAULT_CLI_CONFIG, DEFAULT_DISCORD_SETTINGS, DEFAULT_EDIT_HISTORY_SETTINGS, DEFAULT_GEMINI_EMBEDDING_MODEL, DEFAULT_LANGFUSE_SETTINGS, DEFAULT_PRIVACY_SETTINGS, DEFAULT_WORKSPACE_FOLDER, hasVerifiedCli } from "src/types";
 import { initLocale, t } from "src/i18n";
 import { registerWorkflowCodeBlockProcessor } from "src/ui/workflowCodeBlock";
 import { initDiscordService, resetDiscordService } from "src/core/discordService";
@@ -589,6 +589,11 @@ export class LlmHubPlugin extends Plugin {
       localLlmConfig: undefined,
       localLlmVerified: undefined,
       localLlmAvailableModels: undefined,
+      // Deep merge privacy settings
+      privacy: {
+        ...DEFAULT_PRIVACY_SETTINGS,
+        ...(loaded.privacy ?? {}),
+      },
       // Deep merge Discord settings
       discord: {
         ...DEFAULT_DISCORD_SETTINGS,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -141,6 +141,9 @@ export interface LlmHubSettings {
   listNotesLimit: number;             // listNotesのデフォルト件数制限
   maxNoteChars: number;               // ノート読み込み時の最大文字数
 
+  // Privacy ACL
+  privacy: PrivacySettings;
+
   // Edit history settings
   editHistory: EditHistorySettings;
 
@@ -163,6 +166,19 @@ export interface LlmHubSettings {
   proxyUrl?: string;              // HTTP(S) proxy URL (e.g. http://proxy:8080)
   proxyBypass?: string;           // Comma-separated hosts to bypass proxy (e.g. api.openai.com,localhost)
 }
+
+// Privacy ACL settings — restrict cloud providers from accessing private notes
+export interface PrivacySettings {
+  enabled: boolean;
+  privateTag: string;
+  privateFolders: string[];
+}
+
+export const DEFAULT_PRIVACY_SETTINGS: PrivacySettings = {
+  enabled: false,
+  privateTag: "private",
+  privateFolders: [],
+};
 
 // Edit history settings
 export interface EditHistorySettings {
@@ -920,6 +936,8 @@ export const DEFAULT_SETTINGS: LlmHubSettings = {
   functionCallWarningThreshold: 5,
   listNotesLimit: 50,
   maxNoteChars: 20000,
+  // Privacy
+  privacy: DEFAULT_PRIVACY_SETTINGS,
   // Edit history
   editHistory: DEFAULT_EDIT_HISTORY_SETTINGS,
   // Encryption

--- a/src/ui/SettingsTab.tsx
+++ b/src/ui/SettingsTab.tsx
@@ -14,6 +14,7 @@ import { displayMcpServersSettings } from "src/ui/settings/mcpServersSettings";
 import { displayApiProviderSettings } from "src/ui/settings/apiProviderSettings";
 import { displayProxySettings } from "src/ui/settings/proxySettings";
 import { displayDiscordSettings } from "src/ui/settings/discordSettings";
+import { displayPrivacySettings } from "src/ui/settings/privacySettings";
 
 export class SettingsTab extends PluginSettingTab {
   plugin: LlmHubPlugin;
@@ -40,6 +41,7 @@ export class SettingsTab extends PluginSettingTab {
     displayApiProviderSettings(containerEl, ctx);
     displayProxySettings(containerEl, ctx);
     displayWorkspaceSettings(containerEl, ctx);
+    displayPrivacySettings(containerEl, ctx);
     displayEditHistorySettings(containerEl, ctx);
     displayEncryptionSettings(containerEl, ctx);
     displayLangfuseSettings(containerEl, ctx);

--- a/src/ui/components/Chat.tsx
+++ b/src/ui/components/Chat.tsx
@@ -56,7 +56,7 @@ import { localLlmChatStream } from "src/core/localLlmProvider";
 import { openaiChatWithToolsStream, openaiGenerateImageStream, isOpenAiImageModel } from "src/core/openaiProvider";
 import { anthropicChatWithToolsStream } from "src/core/anthropicProvider";
 import { searchLocalRag, loadRagMediaAttachments } from "src/core/localRagStore";
-import { createToolExecutor } from "src/vault/toolExecutor";
+import { createToolExecutor, isFilePrivate } from "src/vault/toolExecutor";
 import {
 	getPendingEdit,
 	applyEdit,
@@ -1594,10 +1594,14 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 				const ragSettingObj = plugin.getRagSetting(selectedRagSetting);
 				if (ragSettingObj) {
 					try {
+						const ragPrivacyFilter = isApiProviderModel(currentModel) && plugin.settings.privacy?.enabled
+							? (fp: string) => !isFilePrivate(plugin.app, fp, plugin.settings.privacy)
+							: undefined;
 						const localRag = await searchLocalRag(
 							selectedRagSetting, resolvedContent,
 							ragSettingObj, getGeminiApiKey(plugin.settings),
-							plugin.settings.proxyUrl, plugin.settings.proxyBypass
+							plugin.settings.proxyUrl, plugin.settings.proxyBypass,
+							ragPrivacyFilter,
 						);
 						if (localRag.sources.length > 0) {
 							systemPrompt += localRag.context;
@@ -1875,10 +1879,14 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 				const ragSettingObj = plugin.getRagSetting(selectedRagSetting);
 				if (ragSettingObj) {
 					try {
+						const ragPrivacyFilter = isApiProviderModel(currentModel) && plugin.settings.privacy?.enabled
+							? (fp: string) => !isFilePrivate(plugin.app, fp, plugin.settings.privacy)
+							: undefined;
 						const localRag = await searchLocalRag(
 							selectedRagSetting, resolvedContent,
 							ragSettingObj, getGeminiApiKey(plugin.settings),
-							plugin.settings.proxyUrl, plugin.settings.proxyBypass
+							plugin.settings.proxyUrl, plugin.settings.proxyBypass,
+							ragPrivacyFilter,
 						);
 						if (localRag.sources.length > 0) {
 							systemPrompt += localRag.context;
@@ -1919,10 +1927,12 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 					allowDelete: true,
 					ragEnabled: false,
 				});
-				const obsidianToolExecutor = createToolExecutor(plugin.app, {
-					listNotesLimit: settings.listNotesLimit,
-					maxNoteChars: settings.maxNoteChars,
-				});
+			const obsidianToolExecutor = createToolExecutor(plugin.app, {
+				listNotesLimit: settings.listNotesLimit,
+				maxNoteChars: settings.maxNoteChars,
+				isCloudProvider: isApiProviderModel(currentModel),
+				privacySettings: settings.privacy,
+			});
 
 				// Fetch MCP tools if any servers are enabled
 				let toolsBundle = [...vaultTools];
@@ -2263,10 +2273,14 @@ Always be helpful and provide clear, concise responses. When working with notes,
 				const ragSettingObj = plugin.getRagSetting(selectedRagSetting);
 				if (ragSettingObj) {
 					try {
+						const ragPrivacyFilter = isApiProviderModel(currentModel) && plugin.settings.privacy?.enabled
+							? (fp: string) => !isFilePrivate(plugin.app, fp, plugin.settings.privacy)
+							: undefined;
 						const localRag = await searchLocalRag(
 							selectedRagSetting, resolvedContent,
 							ragSettingObj, getGeminiApiKey(plugin.settings),
-							plugin.settings.proxyUrl, plugin.settings.proxyBypass
+							plugin.settings.proxyUrl, plugin.settings.proxyBypass,
+							ragPrivacyFilter,
 						);
 						if (localRag.sources.length > 0) {
 							systemPrompt += localRag.context;
@@ -2286,12 +2300,14 @@ Always be helpful and provide clear, concise responses. When working with notes,
 				}
 			}
 
-			// Build vault tools (same as Gemini path)
+		// Build vault tools (same as Gemini path)
 			const allMessages = [...messages, userMessage];
 			let tools = getEnabledTools({ allowWrite: true, allowDelete: true, ragEnabled: false });
 			const obsidianToolExecutor = createToolExecutor(plugin.app, {
 				listNotesLimit: settings.listNotesLimit,
 				maxNoteChars: settings.maxNoteChars,
+				isCloudProvider: isApiProviderModel(currentModel),
+				privacySettings: settings.privacy,
 			});
 
 			// Fetch MCP tools
@@ -2702,6 +2718,8 @@ Always be helpful and provide clear, concise responses. When working with notes,
 					? createToolExecutor(plugin.app, {
 						listNotesLimit: settings.listNotesLimit,
 						maxNoteChars: settings.maxNoteChars,
+						isCloudProvider: isApiProviderModel(currentModel),
+						privacySettings: settings.privacy,
 					})
 					: undefined;
 
@@ -3059,10 +3077,14 @@ Always be helpful and provide clear, concise responses. When working with notes,
 					const ragSettingObj = plugin.getRagSetting(selectedRagSetting);
 					if (ragSettingObj) {
 						try {
+							const ragPrivacyFilter = isApiProviderModel(currentModel) && plugin.settings.privacy?.enabled
+								? (fp: string) => !isFilePrivate(plugin.app, fp, plugin.settings.privacy)
+								: undefined;
 							const localRag = await searchLocalRag(
 								selectedRagSetting, resolvedContent,
 								ragSettingObj, getGeminiApiKey(plugin.settings),
-								plugin.settings.proxyUrl, plugin.settings.proxyBypass
+								plugin.settings.proxyUrl, plugin.settings.proxyBypass,
+								ragPrivacyFilter,
 							);
 							if (localRag.sources.length > 0) {
 								systemPrompt += localRag.context;

--- a/src/ui/settings/privacySettings.ts
+++ b/src/ui/settings/privacySettings.ts
@@ -1,0 +1,67 @@
+import { Setting } from "obsidian";
+import { t } from "src/i18n";
+import { DEFAULT_PRIVACY_SETTINGS } from "src/types";
+import type { SettingsContext } from "./settingsContext";
+
+export function displayPrivacySettings(containerEl: HTMLElement, ctx: SettingsContext): void {
+  const { plugin } = ctx;
+  const privacy = plugin.settings.privacy ?? DEFAULT_PRIVACY_SETTINGS;
+
+  new Setting(containerEl).setName(t("settings.privacy" as never)).setHeading();
+
+  new Setting(containerEl)
+    .setName(t("settings.privacyEnabled" as never))
+    .setDesc(t("settings.privacyEnabled.desc" as never))
+    .addToggle((toggle) =>
+      toggle
+        .setValue(privacy.enabled)
+        .onChange((value) => {
+          void (async () => {
+            if (!plugin.settings.privacy) {
+              plugin.settings.privacy = { ...DEFAULT_PRIVACY_SETTINGS };
+            }
+            plugin.settings.privacy.enabled = value;
+            await plugin.saveSettings();
+          })();
+        })
+    );
+
+  new Setting(containerEl)
+    .setName(t("settings.privateTag" as never))
+    .setDesc(t("settings.privateTag.desc" as never))
+    .addText((text) => {
+      text
+        .setPlaceholder(t("settings.privateTag.placeholder" as never))
+        .setValue(privacy.privateTag);
+      text.inputEl.addEventListener("blur", () => {
+        void (async () => {
+          if (!plugin.settings.privacy) {
+            plugin.settings.privacy = { ...DEFAULT_PRIVACY_SETTINGS };
+          }
+          plugin.settings.privacy.privateTag = text.inputEl.value.trim() || DEFAULT_PRIVACY_SETTINGS.privateTag;
+          await plugin.saveSettings();
+        })();
+      });
+    });
+
+  new Setting(containerEl)
+    .setName(t("settings.privateFolders" as never))
+    .setDesc(t("settings.privateFolders.desc" as never))
+    .addText((text) => {
+      text
+        .setPlaceholder(t("settings.privateFolders.placeholder" as never))
+        .setValue(privacy.privateFolders.join(", "));
+      text.inputEl.addEventListener("blur", () => {
+        void (async () => {
+          if (!plugin.settings.privacy) {
+            plugin.settings.privacy = { ...DEFAULT_PRIVACY_SETTINGS };
+          }
+          plugin.settings.privacy.privateFolders = text.inputEl.value
+            .split(",")
+            .map(s => s.trim())
+            .filter(Boolean);
+          await plugin.saveSettings();
+        })();
+      });
+    });
+}

--- a/src/utils/EventEmitter.ts
+++ b/src/utils/EventEmitter.ts
@@ -37,7 +37,7 @@ export class EventEmitter {
     if (!listeners || listeners.size === 0) {
       return false;
     }
-    for (const listener of listeners) {
+    for (const listener of [...listeners]) {
       listener(...args);
     }
     return true;

--- a/src/vault/search.ts
+++ b/src/vault/search.ts
@@ -74,9 +74,11 @@ export interface SearchResult {
 export function searchByName(
   app: App,
   query: string,
-  limit = 10
+  limit = 10,
+  excludeFilter?: (file: TFile) => boolean,
 ): SearchResult[] {
-  const files = getSearchableVaultFiles(app);
+  let files = getSearchableVaultFiles(app);
+  if (excludeFilter) files = files.filter(f => !excludeFilter(f));
   const searchTerm = query.toLowerCase().trim();
 
   const results: SearchResult[] = [];
@@ -85,10 +87,8 @@ export function searchByName(
     const fileName = file.basename.toLowerCase();
     const filePath = file.path.toLowerCase();
 
-    // Calculate relevance score
     let score = 0;
 
-    // Exact match gets highest score
     if (fileName === searchTerm) {
       score = 100;
     } else if (fileName.startsWith(searchTerm)) {
@@ -108,7 +108,6 @@ export function searchByName(
     }
   }
 
-  // Sort by score (descending) and limit results
   return results
     .sort((a, b) => b.score - a.score)
     .slice(0, limit);
@@ -118,9 +117,11 @@ export function searchByName(
 export async function searchByContent(
   app: App,
   query: string,
-  limit = 10
+  limit = 10,
+  excludeFilter?: (file: TFile) => boolean,
 ): Promise<SearchResult[]> {
-  const files = getSearchableVaultFiles(app);
+  let files = getSearchableVaultFiles(app);
+  if (excludeFilter) files = files.filter(f => !excludeFilter(f));
   const searchTerm = query.toLowerCase().trim();
 
   const results: SearchResult[] = [];
@@ -167,9 +168,11 @@ export function listNotes(
   app: App,
   folder?: string,
   recursive = false,
-  limit = DEFAULT_SETTINGS.listNotesLimit
+  limit = DEFAULT_SETTINGS.listNotesLimit,
+  excludeFilter?: (file: TFile) => boolean,
 ): { results: SearchResult[]; totalCount: number; hasMore: boolean } {
   let files = getVaultTextFiles(app);
+  if (excludeFilter) files = files.filter(f => !excludeFilter(f));
 
   if (folder) {
     const normalizedFolder = folder.toLowerCase().replace(/\/$/, "");

--- a/src/vault/toolExecutor.ts
+++ b/src/vault/toolExecutor.ts
@@ -1,4 +1,4 @@
-import type { App } from "obsidian";
+import { TFile, type App } from "obsidian";
 import {
   readNote,
   createNote,
@@ -15,6 +15,7 @@ import {
   proposeBulkEdit,
   proposeBulkDelete,
   proposeBulkRename,
+  findFileByName,
 } from "./notes";
 import {
   searchByName,
@@ -23,7 +24,7 @@ import {
   listFolders,
   createFolder,
 } from "./search";
-import { DEFAULT_SETTINGS } from "src/types";
+import { DEFAULT_SETTINGS, type PrivacySettings } from "src/types";
 import { formatError } from "src/utils/error";
 
 export type ToolResult = Record<string, unknown>;
@@ -32,6 +33,54 @@ export type ToolResult = Record<string, unknown>;
 export interface ToolExecutionContext {
   listNotesLimit?: number;
   maxNoteChars?: number;
+  isCloudProvider?: boolean;
+  privacySettings?: PrivacySettings;
+}
+
+const PRIVACY_DENIED_MSG = "Access denied: this note is marked as private and cannot be accessed by cloud providers.";
+
+export function isFilePrivate(app: App, filePath: string, settings: PrivacySettings): boolean {
+  if (!settings.enabled) return false;
+
+  let resolvedPath = filePath;
+  let resolvedFile = app.vault.getAbstractFileByPath(filePath);
+  if (!resolvedFile || !(resolvedFile instanceof TFile)) {
+    const found = findFileByName(app, filePath);
+    if (found) {
+      resolvedPath = found.path;
+      resolvedFile = found;
+    }
+  }
+
+  const normalizedPath = resolvedPath.toLowerCase();
+  for (const folder of settings.privateFolders) {
+    const normalizedFolder = folder.toLowerCase().replace(/\/$/, "");
+    if (normalizedPath.startsWith(normalizedFolder + "/") || normalizedPath === normalizedFolder) {
+      return true;
+    }
+  }
+
+  if (resolvedFile instanceof TFile) {
+    const cache = app.metadataCache.getFileCache(resolvedFile);
+    const tags: unknown = cache?.frontmatter?.tags;
+    if (Array.isArray(tags) && tags.includes(settings.privateTag)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function privacyBlocked(context: ToolExecutionContext | undefined): boolean {
+  return !!(context?.isCloudProvider && context?.privacySettings?.enabled);
+}
+
+function checkFilePrivacy(app: App, filePath: string, context: ToolExecutionContext | undefined): ToolResult | null {
+  if (!privacyBlocked(context)) return null;
+  if (isFilePrivate(app, filePath, context!.privacySettings!)) {
+    return { success: false, error: PRIVACY_DENIED_MSG };
+  }
+  return null;
 }
 
 // Execute a tool call and return the result
@@ -69,19 +118,30 @@ async function executeToolCallInternal(
   context?: ToolExecutionContext
 ): Promise<ToolResult> {
   switch (toolName) {
-    case "read_note":
+    case "read_note": {
+      const fileName = asString(args.fileName);
+      if (fileName) {
+        const denied = checkFilePrivacy(app, fileName, context);
+        if (denied) return denied;
+      }
+      if (args.activeNote && privacyBlocked(context)) {
+        const activeFile = app.workspace.getActiveFile();
+        if (activeFile && isFilePrivate(app, activeFile.path, context!.privacySettings!)) {
+          return { success: false, error: PRIVACY_DENIED_MSG };
+        }
+      }
       return readNote(
         app,
-        asString(args.fileName),
+        fileName,
         args.activeNote as boolean | undefined,
         context?.maxNoteChars ?? DEFAULT_SETTINGS.maxNoteChars
       );
+    }
 
     case "create_note": {
       let name = asString(args.name);
       let folder = asString(args.folder);
       if (!name && args.path) {
-        // Fallback: extract name and folder from path argument
         const pathStr = asString(args.path) || "";
         const lastSlash = pathStr.lastIndexOf("/");
         if (lastSlash >= 0) {
@@ -97,6 +157,10 @@ async function executeToolCallInternal(
       if (args.content == null) {
         return { success: false, error: "Required parameter 'content' is missing" };
       }
+      if (folder) {
+        const denied = checkFilePrivacy(app, folder + "/", context);
+        if (denied) return denied;
+      }
       return createNote(
         app,
         name,
@@ -106,21 +170,35 @@ async function executeToolCallInternal(
       );
     }
 
-    case "update_note":
+    case "update_note": {
+      const updateFileName = asString(args.fileName);
+      if (updateFileName) {
+        const denied = checkFilePrivacy(app, updateFileName, context);
+        if (denied) return denied;
+      }
+      if (args.activeNote && privacyBlocked(context)) {
+        const activeFile = app.workspace.getActiveFile();
+        if (activeFile && isFilePrivate(app, activeFile.path, context!.privacySettings!)) {
+          return { success: false, error: PRIVACY_DENIED_MSG };
+        }
+      }
       return updateNote(
         app,
-        asString(args.fileName),
+        updateFileName,
         args.activeNote as boolean | undefined,
         asString(args.newContent),
         (asString(args.mode) as "replace" | "append" | "prepend") || "replace"
       );
+    }
 
     case "delete_note": {
-      const fileName = asString(args.fileName);
-      if (!fileName) {
+      const deleteFileName = asString(args.fileName);
+      if (!deleteFileName) {
         return { success: false, error: "Required parameter 'fileName' is missing" };
       }
-      return deleteNote(app, fileName);
+      const denied = checkFilePrivacy(app, deleteFileName, context);
+      if (denied) return denied;
+      return deleteNote(app, deleteFileName);
     }
 
     case "rename_note": {
@@ -132,6 +210,8 @@ async function executeToolCallInternal(
       if (!newPath) {
         return { success: false, error: "Required parameter 'newPath' is missing" };
       }
+      const denied = checkFilePrivacy(app, oldPath, context);
+      if (denied) return denied;
       return proposeRename(app, oldPath, newPath);
     }
 
@@ -143,9 +223,12 @@ async function executeToolCallInternal(
       const searchContent = args.searchContent as boolean | undefined;
       const parsedLimit = args.limit ? parseInt(asString(args.limit) || "10", 10) : 10;
       const limit = Number.isNaN(parsedLimit) || parsedLimit <= 0 ? 10 : parsedLimit;
+      const privacyFilter = privacyBlocked(context)
+        ? (f: TFile) => isFilePrivate(app, f.path, context!.privacySettings!)
+        : undefined;
 
       if (searchContent) {
-        const results = await searchByContent(app, query, limit);
+        const results = await searchByContent(app, query, limit, privacyFilter);
         return {
           success: true,
           results: results.map((r) => ({
@@ -156,7 +239,7 @@ async function executeToolCallInternal(
           count: results.length,
         };
       } else {
-        const results = searchByName(app, query, limit);
+        const results = searchByName(app, query, limit, privacyFilter);
         return {
           success: true,
           results: results.map((r) => ({ name: r.name, path: r.path })),
@@ -171,7 +254,10 @@ async function executeToolCallInternal(
       const defaultLimit = context?.listNotesLimit ?? DEFAULT_SETTINGS.listNotesLimit;
       const parsedLimit = args.limit ? parseInt(asString(args.limit) || String(defaultLimit), 10) : defaultLimit;
       const limit = Number.isNaN(parsedLimit) || parsedLimit <= 0 ? defaultLimit : parsedLimit;
-      const { results, totalCount, hasMore } = listNotes(app, folder, recursive, limit);
+      const privacyFilter = privacyBlocked(context)
+        ? (f: TFile) => isFilePrivate(app, f.path, context!.privacySettings!)
+        : undefined;
+      const { results, totalCount, hasMore } = listNotes(app, folder, recursive, limit, privacyFilter);
       return {
         success: true,
         notes: results.map((r) => ({ name: r.name, path: r.path })),
@@ -203,6 +289,12 @@ async function executeToolCallInternal(
     }
 
     case "get_active_note_info": {
+      if (privacyBlocked(context)) {
+        const activeFile = app.workspace.getActiveFile();
+        if (activeFile && isFilePrivate(app, activeFile.path, context!.privacySettings!)) {
+          return { success: false, error: PRIVACY_DENIED_MSG };
+        }
+      }
       const info = getActiveNoteInfo(app);
       if (info) {
         return { success: true, ...info };
@@ -213,16 +305,28 @@ async function executeToolCallInternal(
       };
     }
 
-    case "propose_edit":
+    case "propose_edit": {
+      const editFileName = asString(args.fileName);
+      if (editFileName) {
+        const denied = checkFilePrivacy(app, editFileName, context);
+        if (denied) return denied;
+      }
+      if (args.activeNote && privacyBlocked(context)) {
+        const activeFile = app.workspace.getActiveFile();
+        if (activeFile && isFilePrivate(app, activeFile.path, context!.privacySettings!)) {
+          return { success: false, error: PRIVACY_DENIED_MSG };
+        }
+      }
       return proposeEdit(
         app,
-        asString(args.fileName),
+        editFileName,
         args.activeNote as boolean | undefined,
         asString(args.newContent),
         (asString(args.mode) as "replace" | "append" | "prepend" | "patch") || "replace",
         undefined,
         args.patches as Array<{ search: string; replace: string }> | undefined
       );
+    }
 
     case "apply_edit":
       return applyEdit(app);
@@ -231,11 +335,13 @@ async function executeToolCallInternal(
       return discardEdit(app);
 
     case "propose_delete": {
-      const fileName = asString(args.fileName);
-      if (!fileName) {
+      const proposeDeleteFileName = asString(args.fileName);
+      if (!proposeDeleteFileName) {
         return { success: false, error: "Required parameter 'fileName' is missing" };
       }
-      return proposeDelete(app, fileName);
+      const denied = checkFilePrivacy(app, proposeDeleteFileName, context);
+      if (denied) return denied;
+      return proposeDelete(app, proposeDeleteFileName);
     }
 
     case "apply_delete":
@@ -245,7 +351,7 @@ async function executeToolCallInternal(
       return discardDelete(app);
 
     case "bulk_propose_edit": {
-      const edits = args.edits as Array<{
+      let edits = args.edits as Array<{
         fileName: string;
         newContent: string;
         mode?: "replace" | "append" | "prepend";
@@ -256,27 +362,39 @@ async function executeToolCallInternal(
           error: "No edits provided. The 'edits' array is required.",
         };
       }
+      if (privacyBlocked(context)) {
+        edits = edits.filter(e => !isFilePrivate(app, e.fileName, context!.privacySettings!));
+        if (edits.length === 0) return { success: false, error: PRIVACY_DENIED_MSG };
+      }
       return proposeBulkEdit(app, edits);
     }
 
     case "bulk_propose_rename": {
-      const renames = args.renames as Array<{ oldPath: string; newPath: string }>;
+      let renames = args.renames as Array<{ oldPath: string; newPath: string }>;
       if (!renames || !Array.isArray(renames) || renames.length === 0) {
         return {
           success: false,
           error: "No renames provided. The 'renames' array is required.",
         };
       }
+      if (privacyBlocked(context)) {
+        renames = renames.filter(r => !isFilePrivate(app, r.oldPath, context!.privacySettings!));
+        if (renames.length === 0) return { success: false, error: PRIVACY_DENIED_MSG };
+      }
       return proposeBulkRename(app, renames);
     }
 
     case "bulk_propose_delete": {
-      const fileNames = args.fileNames as string[];
+      let fileNames = args.fileNames as string[];
       if (!fileNames || !Array.isArray(fileNames) || fileNames.length === 0) {
         return {
           success: false,
           error: "No files provided. The 'fileNames' array is required.",
         };
+      }
+      if (privacyBlocked(context)) {
+        fileNames = fileNames.filter(f => !isFilePrivate(app, f, context!.privacySettings!));
+        if (fileNames.length === 0) return { success: false, error: PRIVACY_DENIED_MSG };
       }
       return proposeBulkDelete(app, fileNames);
     }


### PR DESCRIPTION
## Message to the creator

Hi! First of all, thanks for making this plugin, it's amazing and exactly what I was looking for.

As a very unorganized person, I find that creating and organizing notes through chat with an LLM is amazing. At first, I thought I would only use local models and therefore wouldn't have to care about separating personal and non-personal notes, but I find access to larger, cloud models useful for some tasks, but then you run into the privacy issue.

So I've tried to solve this, by adding (well, having Claude add) a very convenient privacy layer, where you can define tags or folders that will only be accessible to local models. So now I don't have to deal with separate vaults or worry about my more private data ending up somewhere, I just add the "private" tag and it seems to work perfectly, local models had access, cloud ones didn't.

I also ran repeatedly into a bug where the app would freeze when I was attempting to change the plugin settings, and with the new privacy toggle this cause real issues, so I asked Claude to fix that as well.

I hope you will this interesting and potentially helpful and not just an AI slop PR. Thanks again for making this!

## Technical summary

- Add tag-based and folder-based privacy ACL for cloud/API providers while leaving local LLMs unrestricted.
- Private notes are blocked for vault write/read tools on cloud models: `read_note`, `update_note`, `delete_note`, `propose_edit`, `propose_delete`, `rename_note`, and `get_active_note_info` return access denied.
- `search_notes` and `list_notes` omit private files from results.
- `searchLocalRag` filters private files before semantic context is injected.
- Bulk tools (`bulk_propose_edit`, `bulk_propose_rename`, `bulk_propose_delete`) filter individual items instead of exposing private notes.
- New settings UI adds a privacy toggle plus inputs for private tags and private folders.
- Settings loading now deep-merges privacy defaults.
- `EventEmitter.emit()` now snapshots listeners before iterating, preventing the recursive freeze when listeners re-register during settings refresh.

## Files changed

- `src/ui/settings/privacySettings.ts` — new privacy settings UI section.
- `src/types/index.ts` — added `PrivacySettings`, defaults, and `privacy` on `LlmHubSettings`.
- `src/vault/toolExecutor.ts` — privacy checks for private files and cloud providers.
- `src/vault/search.ts` — optional exclude filter for note search/listing.
- `src/ui/components/Chat.tsx` — passes cloud/privacy context into tool execution and RAG search.
- `src/core/localRagStore.ts` — supports file filtering during RAG search.
- `src/plugin.ts` — merges privacy settings defaults when loading.
- `src/ui/SettingsTab.tsx` — wires the new privacy settings section into the UI.
- `src/i18n/en.ts` — adds privacy settings translations.
- `src/utils/EventEmitter.ts` — snapshots listeners before emit.
