### PR TITLE
feat: remember diff review view state

### DIFF
--- a/src/ui/components/workflow/AIWorkflowModal.ts
+++ b/src/ui/components/workflow/AIWorkflowModal.ts
@@ -11,6 +11,7 @@ import type { SidebarNode, WorkflowNodeType, ExecutionStep } from "src/workflow/
 import { findWorkflowBlocks, normalizeYamlText } from "src/workflow/parser";
 import { ExecutionHistoryManager } from "src/workflow/history";
 import { renderDiffView, createDiffViewToggle, formatLineComments, type DiffRendererState } from "./DiffRenderer";
+import { getDiffViewModePreference, setDiffViewModePreference } from "./diffViewPreference";
 import { WorkflowGenerationModal } from "./WorkflowGenerationModal";
 import { showWorkflowPreview } from "./WorkflowPreviewModal";
 import { showExecutionHistorySelect } from "./ExecutionHistorySelectModal";
@@ -175,9 +176,14 @@ class WorkflowConfirmModal extends Modal {
           instrWrapper,
           this.oldInstructions ?? "",
           this.newInstructions,
-          { enableComments: false },
+          {
+            enableComments: false,
+            viewMode: getDiffViewModePreference(this.app),
+          },
         );
-        createDiffViewToggle(instrLabel, this.instructionsDiffState);
+        createDiffViewToggle(instrLabel, this.instructionsDiffState, (viewMode) => {
+          setDiffViewModePreference(this.app, viewMode);
+        });
       }
     }
 
@@ -198,8 +204,11 @@ class WorkflowConfirmModal extends Modal {
       const diffWrapper = scrollable.createDiv({ cls: "ai-workflow-confirm-diff-wrapper ai-workflow-confirm-diff" });
       this.diffState = renderDiffView(diffWrapper, this.oldYaml, this.newYaml, {
         enableComments: true,
+        viewMode: getDiffViewModePreference(this.app),
       });
-      createDiffViewToggle(diffLabel, this.diffState);
+      createDiffViewToggle(diffLabel, this.diffState, (viewMode) => {
+        setDiffViewModePreference(this.app, viewMode);
+      });
     }
 
     // Generation context (plan/thinking/review)
@@ -237,22 +246,17 @@ class WorkflowConfirmModal extends Modal {
       text: t("message.requestChanges"),
       cls: "mod-warning",
     });
-    const updateRequestChangesState = () => {
-      const hasComments = this.diffState ? this.diffState.lineComments.size > 0 : false;
-      const hasText = !!(this.additionalRequestEl?.value?.trim());
-      requestChangesBtn.disabled = !hasComments && !hasText;
-    };
-    // Start disabled — enabled once the user types a refinement or adds a line comment.
-    requestChangesBtn.disabled = true;
-    if (this.diffState) {
-      this.diffState.onCommentsChange = () => updateRequestChangesState();
-    }
-    this.additionalRequestEl.addEventListener("input", () => updateRequestChangesState());
     requestChangesBtn.addEventListener("click", () => {
       const generalFeedback = this.additionalRequestEl?.value?.trim() || "";
       const lineCommentsFeedback = this.diffState
         ? formatLineComments("workflow", this.diffState.lineComments)
         : "";
+
+      if (!lineCommentsFeedback && !generalFeedback) {
+        this.additionalRequestEl?.focus();
+        return;
+      }
+
       const parts: string[] = [];
       if (lineCommentsFeedback) parts.push(lineCommentsFeedback);
       if (generalFeedback) parts.push(generalFeedback);

--- a/src/ui/components/workflow/EditConfirmationModal.ts
+++ b/src/ui/components/workflow/EditConfirmationModal.ts
@@ -1,7 +1,12 @@
 import { Modal, App, MarkdownRenderer, Component, setIcon } from "obsidian";
 import { t } from "src/i18n";
 import { renderDiffView, formatLineComments, createDiffViewToggle, type DiffRendererState } from "./DiffRenderer";
-import { getDiffViewModePreference, setDiffViewModePreference } from "./diffViewPreference";
+import {
+  getDiffFullscreenPreference,
+  getDiffViewModePreference,
+  setDiffFullscreenPreference,
+  setDiffViewModePreference,
+} from "./diffViewPreference";
 import { getOpenFileAfterApplyPreference, setOpenFileAfterApplyPreference } from "src/vault/notes";
 
 /**
@@ -169,6 +174,7 @@ export class EditConfirmationModal extends Modal {
     fullscreenBtn.addEventListener("click", () => {
       this.toggleFullscreen(modalEl, fullscreenBtn);
     });
+    this.setFullscreen(modalEl, fullscreenBtn, getDiffFullscreenPreference(this.app), false);
 
     // File path display
     const pathRow = header.createDiv({ cls: "llm-hub-edit-confirm-path" });
@@ -349,13 +355,26 @@ export class EditConfirmationModal extends Modal {
   }
 
   private toggleFullscreen(modalEl: HTMLElement, button: HTMLButtonElement): void {
-    this.isFullscreen = !this.isFullscreen;
-    modalEl.toggleClass("is-fullscreen", this.isFullscreen);
+    this.setFullscreen(modalEl, button, !this.isFullscreen, true);
+  }
 
-    const label = t(this.isFullscreen ? "diff.restoreSize" : "diff.fullscreen");
+  private setFullscreen(
+    modalEl: HTMLElement,
+    button: HTMLButtonElement,
+    fullscreen: boolean,
+    persist: boolean,
+  ): void {
+    this.isFullscreen = fullscreen;
+    modalEl.toggleClass("is-fullscreen", fullscreen);
+
+    const label = t(fullscreen ? "diff.restoreSize" : "diff.fullscreen");
     button.setAttribute("aria-label", label);
     button.setAttribute("title", label);
-    setIcon(button, this.isFullscreen ? "minimize-2" : "maximize-2");
+    setIcon(button, fullscreen ? "minimize-2" : "maximize-2");
+
+    if (persist) {
+      setDiffFullscreenPreference(this.app, fullscreen);
+    }
   }
 
   private addResizeHandles(modalEl: HTMLElement) {
@@ -979,7 +998,14 @@ export class BulkEditConfirmationModal extends Modal {
 
   private renderPreview(container: HTMLElement, item: BulkEditConfirmItem) {
     const preview = container.createDiv({ cls: "llm-hub-bulk-preview" });
-    renderDiffView(preview, item.originalContent, item.newContent);
+    const previewLabel = preview.createDiv({ cls: "llm-hub-edit-confirm-preview-label" });
+    previewLabel.createSpan({ text: t("workflowModal.changes") });
+    const diffState = renderDiffView(preview, item.originalContent, item.newContent, {
+      viewMode: getDiffViewModePreference(this.app),
+    });
+    createDiffViewToggle(previewLabel, diffState, (viewMode) => {
+      setDiffViewModePreference(this.app, viewMode);
+    });
   }
 
   private getModeLabel(mode: string): string {

--- a/src/ui/components/workflow/diffViewPreference.test.ts
+++ b/src/ui/components/workflow/diffViewPreference.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from "vitest";
 import type { App } from "obsidian";
-import { getDiffViewModePreference, setDiffViewModePreference } from "./diffViewPreference";
+import {
+  getDiffFullscreenPreference,
+  getDiffViewModePreference,
+  setDiffFullscreenPreference,
+  setDiffViewModePreference,
+} from "./diffViewPreference";
 
-function makeApp(initialValue?: unknown): {
+function makeApp(initialValues: Record<string, unknown> = {}): {
   app: App;
   storedValues: Map<string, unknown>;
 } {
-  const storedValues = new Map<string, unknown>();
-  if (initialValue !== undefined) storedValues.set("llm-hub-diff-view-mode", initialValue);
+  const storedValues = new Map<string, unknown>(Object.entries(initialValues));
 
   const app = {
     loadLocalStorage: (key: string) => storedValues.get(key),
@@ -20,11 +24,11 @@ function makeApp(initialValue?: unknown): {
 describe("diff view preference", () => {
   it("defaults invalid or missing values to split view", () => {
     expect(getDiffViewModePreference(makeApp().app)).toBe("split");
-    expect(getDiffViewModePreference(makeApp("invalid").app)).toBe("split");
+    expect(getDiffViewModePreference(makeApp({ "llm-hub-diff-view-mode": "invalid" }).app)).toBe("split");
   });
 
   it("restores and saves each supported view mode", () => {
-    const { app, storedValues } = makeApp("unified");
+    const { app, storedValues } = makeApp({ "llm-hub-diff-view-mode": "unified" });
     expect(getDiffViewModePreference(app)).toBe("unified");
 
     setDiffViewModePreference(app, "split");
@@ -32,5 +36,28 @@ describe("diff view preference", () => {
 
     setDiffViewModePreference(app, "unified");
     expect(storedValues.get("llm-hub-diff-view-mode")).toBe("unified");
+  });
+});
+
+describe("diff fullscreen preference", () => {
+  it("defaults missing or invalid values to windowed", () => {
+    expect(getDiffFullscreenPreference(makeApp().app)).toBe(false);
+    expect(getDiffFullscreenPreference(makeApp({ "llm-hub-diff-fullscreen": "invalid" }).app)).toBe(false);
+  });
+
+  it("restores boolean and string fullscreen values", () => {
+    expect(getDiffFullscreenPreference(makeApp({ "llm-hub-diff-fullscreen": true }).app)).toBe(true);
+    expect(getDiffFullscreenPreference(makeApp({ "llm-hub-diff-fullscreen": "true" }).app)).toBe(true);
+    expect(getDiffFullscreenPreference(makeApp({ "llm-hub-diff-fullscreen": "false" }).app)).toBe(false);
+  });
+
+  it("saves both fullscreen states explicitly", () => {
+    const { app, storedValues } = makeApp();
+
+    setDiffFullscreenPreference(app, true);
+    expect(storedValues.get("llm-hub-diff-fullscreen")).toBe("true");
+
+    setDiffFullscreenPreference(app, false);
+    expect(storedValues.get("llm-hub-diff-fullscreen")).toBe("false");
   });
 });

--- a/src/ui/components/workflow/diffViewPreference.ts
+++ b/src/ui/components/workflow/diffViewPreference.ts
@@ -3,6 +3,7 @@ import type { App } from "obsidian";
 export type DiffViewMode = "unified" | "split";
 
 const DIFF_VIEW_MODE_KEY = "llm-hub-diff-view-mode";
+const DIFF_FULLSCREEN_KEY = "llm-hub-diff-fullscreen";
 
 export function getDiffViewModePreference(app: App): DiffViewMode {
   return app.loadLocalStorage(DIFF_VIEW_MODE_KEY) === "unified" ? "unified" : "split";
@@ -10,4 +11,15 @@ export function getDiffViewModePreference(app: App): DiffViewMode {
 
 export function setDiffViewModePreference(app: App, viewMode: DiffViewMode): void {
   app.saveLocalStorage(DIFF_VIEW_MODE_KEY, viewMode);
+}
+
+export function getDiffFullscreenPreference(app: App): boolean {
+  const stored: unknown = app.loadLocalStorage(DIFF_FULLSCREEN_KEY);
+  return stored === true || stored === "true";
+}
+
+export function setDiffFullscreenPreference(app: App, fullscreen: boolean): void {
+  // Obsidian clears local storage entries for falsy values, so keep both states
+  // as strings to ensure a restored windowed preference is explicit.
+  app.saveLocalStorage(DIFF_FULLSCREEN_KEY, fullscreen ? "true" : "false");
 }

--- a/styles.css
+++ b/styles.css
@@ -3988,6 +3988,14 @@ body.llm-hub-hide-workspace-folder .nav-folder > .nav-folder-title[data-path="LL
   overflow-y: auto;
 }
 
+.llm-hub-bulk-preview .llm-hub-edit-confirm-preview-label {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding-bottom: 8px;
+  background: var(--background-primary);
+}
+
 .llm-hub-bulk-preview .llm-hub-edit-confirm-preview-content {
   padding: 0;
   border: none;


### PR DESCRIPTION
## Summary

- remember the edit confirmation fullscreen state in vault-local storage
- share the remembered Unified/Split preference across note edits, AI workflow diffs, and bulk-edit previews
- make an empty AI workflow Request changes action focus the feedback field instead of disabling the action
- cover the remaining follow-up items from #48

## Compatibility and migration

- existing users continue to default to Split and windowed mode when no preference has been saved
- preferences use Obsidian local storage; no vault files or plugin settings migrations are required
- no plugin version bump is included

## Documentation

- no documentation changes are needed for these self-explanatory modal controls

## Validation

- `npm run lint` (0 errors; 3 existing Obsidian settings API deprecation warnings)
- `TZ=UTC npm test -- --run` (293 passed, 12 skipped)
- `npm run build`
- `git diff --check`
- verified the regenerated built-in help bundle has identical decompressed content and excluded its gzip metadata-only diff
- installed the built assets in the local Obsidian vault without changing `data.json`; requester confirmed the behavior works in Obsidian
